### PR TITLE
link DOIs to preferred resolver

### DIFF
--- a/server.R
+++ b/server.R
@@ -39,7 +39,7 @@ function(input, output, session) {
     totable <- deptData()
     
     totable <- totable %>% 
-      mutate(url = paste0("<a target='blank' href='http://dx.doi.org/", doi, "'>", doi, "</a>"),
+      mutate(url = paste0("<a target='blank' href='https://doi.org/", doi, "'>", doi, "</a>"),
              oa_url = ifelse(!is.na(urls),
                              paste0("<a target='blank' href='", urls, "'>", urls, "</a>"),
                              urls)) %>% 


### PR DESCRIPTION
Hello!

The DOI foundation recommends a [new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8).

Cheers :-)